### PR TITLE
build: provide a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build
+
+VERSION := 43
+TYPE    := standard-virt
+
+build:
+	@sudo IMAGE_BUILDER_EXPERIMENTAL=yamldir=./fedora/defs image-builder --data-dir=./fedora/data build --distro teamsbc-$(DISTRO) $(TYPE)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # TeamSBC Definitions
 
 This repository contains the [image-builder](https://osbuild.org/docs/developer-guide/projects/image-builder/) definitions for the various TeamSBC artifacts. Artifacts are also built here through the use of GitHub actions.
+
+## Building
+
+You can build artifacts locally using the provided `Makefile` in this repository after you've installed the preqrequisites.
+
+### Prerequisites
+
+- `image-builder`
+
+### Usage
+
+```
+make build DISTRO=44 TYPE=standard-virt
+```
+
+Will build a TeamSBC Remix, Fedora 44 based `standard-virt` artifact.


### PR DESCRIPTION
Provide an initial `Makefile` so users do not have to guess or remember long `image-builder` commands.

Closes #12 and #2. These will need to be expanded in follow-ups.