### PR TITLE
defs: don't write timezone

### DIFF
--- a/fedora/defs/fedora/imagetypes.yaml
+++ b/fedora/defs/fedora/imagetypes.yaml
@@ -144,7 +144,6 @@ image_config:
       - "C"
     locale: "C.UTF-8"
     machine_id_uninitialized: true
-    timezone: "UTC"
     mount_units: true
     kernel_options:
       - "rw"


### PR DESCRIPTION
Let the timezone be configured by `systemd-firstboot` instead. Closes #17 [1].

[1]: https://github.com/teamsbc/artifacts/issues/17