### PR TITLE
packages: drop sudo

### DIFF
--- a/data/defs/teamsbc/imagetypes.yaml
+++ b/data/defs/teamsbc/imagetypes.yaml
@@ -19,6 +19,7 @@
         - "firewalld"
         - "plymouth"
         - "kmscon"
+        - "sudo"
     - &packages_standard
       include:
         - "teamsbc-release-standard"


### PR DESCRIPTION
Drop `sudo` from the default set of packages for all variants; instead users can use `run0`.

---

See: https://github.com/teamsbc/distribution/issues/13