### PR TITLE
many: switch to using systemd-boot

### DIFF
--- a/data/defs/library/disk/partitions.yaml
+++ b/data/defs/library/disk/partitions.yaml
@@ -1,11 +1,11 @@
 ---
 esp: &esp
-  size: "200 MiB"
+  size: "1 GiB"
   type: !xref "library/dps.yaml#esp"
   payload_type: "filesystem"
   payload:
     type: vfat
-    mountpoint: "/boot/efi"
+    mountpoint: "/boot"
     label: "ESP"
     fstab_options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
     fstab_freq: 0

--- a/data/defs/library/packages.yaml
+++ b/data/defs/library/packages.yaml
@@ -6,7 +6,6 @@ core: &core
     - "systemd-networkd"
     - "systemd-networkd-defaults"
     - "dbus"
-    - "grubby"
     - "fwupd-efi"
     - "libxkbcommon"
     - "linux-firmware"
@@ -18,6 +17,8 @@ core: &core
     - "plymouth"
     - "kmscon"
     - "sudo"
+    # We don't want /boot/efi to exist as we don't use it
+    - "efi-filesystem"
 
 standard: &standard
   include:

--- a/data/defs/library/platforms.yaml
+++ b/data/defs/library/platforms.yaml
@@ -7,10 +7,8 @@ x86_64_uefi: &x86_64_uefi
   packages:
     uefi:
       - "dracut-config-generic"
-      - "efibootmgr"
-      - "grub2-efi-x64"
-      - "shim-x64"
-  bootloader: "grub2"
+      - "systemd-boot"
+  bootloader: "systemd"
 
 aarch64_uefi: &aarch64_uefi
   arch: "aarch64"
@@ -20,8 +18,5 @@ aarch64_uefi: &aarch64_uefi
   packages:
     uefi:
       - "dracut-config-generic"
-      - "efibootmgr"
-      - "grub2-efi-aa64"
-      - "grub2-tools"
-      - "shim-aa64"
-  bootloader: "grub2"
+      - "systemd-boot"
+  bootloader: "systemd"

--- a/data/defs/teamsbc.yaml
+++ b/data/defs/teamsbc.yaml
@@ -32,8 +32,6 @@ distros:
         kernel_options:
           - "rw"
         kernel_options_bootloader: true
-        grub2_config:
-          timeout: 5
         authselect:
           profile: "local"
           features:


### PR DESCRIPTION
Switch over the `standard` image type to use `systemd-boot`. This cannot land yet as upstream `image-builder` hasn't landed support but a PR for this is open [1].

[1]: https://github.com/osbuild/images/pull/2392